### PR TITLE
[dependabot npm disable] Temporarily disable npm version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,406 +1,357 @@
 version: 2
 updates:
-
-# We currently have CI to make sure that all python `requirements.txt` files
-# are listed here, and only existing `requirements.txt` files are listed here.
-#
-# Until https://github.com/envoyproxy/envoy/issues/26163 is resolved `Dockerfiles`,
-# and `go.mod` files need to be kept in sync manually.
-#
-# Please ensure any new ones are added here, and any that are removed are removed here also.
-
-- package-ecosystem: "pip"
-  directory: "/examples/grpc-bridge/client"
-  groups:
-    examples-grpc-bridge:
-      patterns:
-      - "*"
-  schedule:
-    interval: "daily"
-    time: "06:00"
-
-- package-ecosystem: "pip"
-  directory: "/examples/cache"
-  groups:
-    examples-cache:
-      patterns:
-      - "*"
-  schedule:
-    interval: "daily"
-    time: "06:00"
-
-- package-ecosystem: "pip"
-  directory: "/examples/shared/python/aiohttp"
-  groups:
-    examples-shared-python:
-      patterns:
-      - "*"
-  schedule:
-    interval: "daily"
-    time: "06:00"
-
-- package-ecosystem: "pip"
-  directory: "/examples/shared/python/postgres"
-  groups:
-    examples-postgres:
-      patterns:
-      - "*"
-  schedule:
-    interval: "daily"
-    time: "06:00"
-
-- package-ecosystem: "pip"
-  directory: "/tools/base"
-  open-pull-requests-limit: 20
-  schedule:
-    interval: "daily"
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/.devcontainer"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/ci"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/ext_authz"
-  groups:
-    examples-ext-authz:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/fault-injection"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/golang-network"
-  groups:
-    examples-golang-network:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/grpc-bridge"
-  groups:
-    examples-grpc-bridge:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/kafka"
-  groups:
-    examples-kafka:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/local_ratelimit"
-  groups:
-    examples-local-ratelimit:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/mysql"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/opentelemetry"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/redis"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/build"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/echo"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-# TODO(phlax): just use above
-- package-ecosystem: "docker"
-  directory: "/examples/shared/echo2"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/golang"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/jaeger"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/node"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/postgres"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/python"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/shared/websocket"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/skywalking"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/udp"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "docker"
-  directory: "/examples/zipkin"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/basic"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/dummy"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/echo"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/metric"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/passthrough"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/access_log"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/action"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/buffer"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/routeconfig"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/property"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/http/test/test_data/websocket"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/filters/network/test/test_data"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/contrib/golang/router/cluster_specifier/test/test_data/simple"
-  groups:
-    contrib-golang:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/ext_authz/auth/grpc-service"
-  groups:
-    examples-ext-authz:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/load-reporting-service"
-  groups:
-    examples-load-reporting:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/grpc-bridge/server"
-  groups:
-    examples-grpc-bridge:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/golang-http/simple"
-  groups:
-    examples-golang-http:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "gomod"
-  directory: "/examples/golang-network/simple"
-  groups:
-    examples-golang-network:
-      patterns:
-      - "*"
-  schedule:
-    interval: daily
-    time: "06:00"
-
-- package-ecosystem: "npm"
-  directory: "/examples/single-page-app/ui"
-  schedule:
-    interval: daily
-    time: "06:00"
+  # We currently have CI to make sure that all python `requirements.txt` files
+  # are listed here, and only existing `requirements.txt` files are listed here.
+  #
+  # Until https://github.com/envoyproxy/envoy/issues/26163 is resolved `Dockerfiles`,
+  # and `go.mod` files need to be kept in sync manually.
+  #
+  # Please ensure any new ones are added here, and any that are removed are removed here also.
+  - package-ecosystem: "pip"
+    directory: "/examples/grpc-bridge/client"
+    groups:
+      examples-grpc-bridge:
+        patterns:
+          - "*"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/examples/cache"
+    groups:
+      examples-cache:
+        patterns:
+          - "*"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/examples/shared/python/aiohttp"
+    groups:
+      examples-shared-python:
+        patterns:
+          - "*"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/examples/shared/python/postgres"
+    groups:
+      examples-postgres:
+        patterns:
+          - "*"
+    schedule:
+      interval: "daily"
+      time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/tools/base"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: "daily"
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/ci"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/ext_authz"
+    groups:
+      examples-ext-authz:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/fault-injection"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/golang-network"
+    groups:
+      examples-golang-network:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/grpc-bridge"
+    groups:
+      examples-grpc-bridge:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/kafka"
+    groups:
+      examples-kafka:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/local_ratelimit"
+    groups:
+      examples-local-ratelimit:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/mysql"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/opentelemetry"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/redis"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/build"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/echo"
+    schedule:
+      interval: daily
+      time: "06:00"
+  # TODO(phlax): just use above
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/echo2"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/golang"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/jaeger"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/node"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/postgres"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/python"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/shared/websocket"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/skywalking"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/udp"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "docker"
+    directory: "/examples/zipkin"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/basic"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/dummy"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/echo"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/metric"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/passthrough"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/access_log"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/action"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/buffer"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/routeconfig"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/property"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/http/test/test_data/websocket"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/filters/network/test/test_data"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/contrib/golang/router/cluster_specifier/test/test_data/simple"
+    groups:
+      contrib-golang:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/examples/ext_authz/auth/grpc-service"
+    groups:
+      examples-ext-authz:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/examples/load-reporting-service"
+    groups:
+      examples-load-reporting:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/examples/grpc-bridge/server"
+    groups:
+      examples-grpc-bridge:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/examples/golang-http/simple"
+    groups:
+      examples-golang-http:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "gomod"
+    directory: "/examples/golang-network/simple"
+    groups:
+      examples-golang-network:
+        patterns:
+          - "*"
+    schedule:
+      interval: daily
+      time: "06:00"
+  - package-ecosystem: "npm"
+    directory: "/examples/single-page-app/ui"
+    schedule:
+      interval: daily
+      time: "06:00"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
This PR temporarily disables Dependabot **npm version updates** by setting `open-pull-requests-limit: 0` for all `package-ecosystem: npm` entries.

Use the matching `enable` script (or manually remove that field) to re-enable npm version updates later.