### PR TITLE
upstream_impl: use a separate root-scoped context for upstream HTTP filters

### DIFF
--- a/envoy/server/filter_config.h
+++ b/envoy/server/filter_config.h
@@ -223,17 +223,6 @@ public:
   createFilterFactoryFromProto(const Protobuf::Message& config,
                                UpstreamFactoryContext& context) PURE;
 
-  // Overload with explicit stats_prefix. Implementations that emit stats should override this;
-  // the default delegates to the 2-arg form so existing implementations need not change.
-  // TODO: thread stats_prefix through
-  // FilterConfigProviderManagerImpl::createDynamicFilterConfigProvider so the ECDS path also passes
-  // "cluster.<name>." rather than "" here.
-  virtual Network::FilterFactoryCb createFilterFactoryFromProto(const Protobuf::Message& config,
-                                                                const std::string& /*stats_prefix*/,
-                                                                UpstreamFactoryContext& context) {
-    return createFilterFactoryFromProto(config, context);
-  }
-
   std::string category() const override { return "envoy.filters.upstream_network"; }
 
   /**

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1253,11 +1253,13 @@ ClusterInfoImpl::ClusterInfoImpl(
               server_context)),
       network_filter_config_provider_manager_(
           createSingletonUpstreamNetworkFilterConfigProviderManager(server_context)),
-      upstream_context_(server_context, init_manager,
-                        Runtime::runtimeFeatureEnabled(
-                            "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
-                            ? server_context.serverScope()
-                            : *stats_scope_),
+      upstream_context_(server_context, init_manager, *stats_scope_),
+      http_upstream_context_(
+          server_context, init_manager,
+          Runtime::runtimeFeatureEnabled(
+              "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
+              ? server_context.serverScope()
+              : *stats_scope_),
       happy_eyeballs_config_(
           config.upstream_connection_options().has_happy_eyeballs_config()
               ? std::make_unique<
@@ -1407,15 +1409,16 @@ ClusterInfoImpl::ClusterInfoImpl(
   // early validation of sanity of fields that we should catch at config ingestion.
   DurationUtil::durationToMilliseconds(common_lb_config_->update_merge_window());
 
-  // When the flag is enabled, upstream_context_ uses the server root scope and both the upstream
-  // network and HTTP filter chains receive an explicit "cluster.<name>." stats_prefix. When
-  // disabled, upstream_context_ keeps the cluster-scoped stats_scope_ and we reproduce the legacy
-  // stats_prefix (the stringified scope prefix) so existing stat names are unchanged.
-  const bool correct_stats_prefix = Runtime::runtimeFeatureEnabled(
-      "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix");
-  const std::string cluster_stats_prefix =
-      correct_stats_prefix ? absl::StrCat("cluster.", name_, ".")
-                           : stats_scope_->symbolTable().toString(stats_scope_->prefix());
+  // stats_prefix passed to the upstream HTTP filter chain. When the correct-stats-prefix flag is
+  // enabled, http_upstream_context_ is scoped to the server root, so pass an explicit
+  // "cluster.<name>." prefix (mirroring the router, which passes the HCM stat prefix). When
+  // disabled, http_upstream_context_ keeps the cluster-scoped stats_scope_, so reproduce the legacy
+  // stringified scope prefix to keep existing stat names unchanged.
+  const std::string http_stats_prefix =
+      Runtime::runtimeFeatureEnabled(
+          "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
+          ? absl::StrCat("cluster.", name_, ".")
+          : stats_scope_->symbolTable().toString(stats_scope_->prefix());
 
   // Create upstream network filter factories
   const auto& filters = config.filters();
@@ -1451,7 +1454,7 @@ ClusterInfoImpl::ClusterInfoImpl(
             proto_config.typed_config(), factory_context.messageValidationVisitor(), *message),
         creation_status);
     Network::FilterFactoryCb callback =
-        factory.createFilterFactoryFromProto(*message, cluster_stats_prefix, upstream_context_);
+        factory.createFilterFactoryFromProto(*message, upstream_context_);
     filter_factories_.push_back(
         network_filter_config_provider_manager_->createStaticFilterConfigProvider(
             callback, proto_config.name()));
@@ -1465,15 +1468,12 @@ ClusterInfoImpl::ClusterInfoImpl(
         return;
       }
 
-      // With the flag on, upstream_context_ uses the server root scope (empty prefix), so pass
-      // "cluster.<name>." explicitly as stats_prefix and HTTP filter stats land under
-      // "cluster.<name>.*", mirroring the router case where the HCM stat prefix is the
-      // stats_prefix.
       Http::FilterChainHelper<Server::Configuration::UpstreamFactoryContext,
                               Server::Configuration::UpstreamHttpFilterConfigFactory>
-          helper(*http_filter_config_provider_manager_, upstream_context_.serverFactoryContext(),
-                 factory_context.serverFactoryContext().clusterManager(), upstream_context_,
-                 cluster_stats_prefix);
+          helper(*http_filter_config_provider_manager_,
+                 http_upstream_context_.serverFactoryContext(),
+                 factory_context.serverFactoryContext().clusterManager(), http_upstream_context_,
+                 http_stats_prefix);
       SET_AND_RETURN_IF_NOT_OK(helper.processFilters(http_protocol_options_->http_filters_,
                                                      "upstream http", "upstream http",
                                                      http_filter_factories_),

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1147,7 +1147,13 @@ private:
   mutable Http::Http1::CodecStats::AtomicPtr http1_codec_stats_;
   mutable Http::Http2::CodecStats::AtomicPtr http2_codec_stats_;
   mutable Http::Http3::CodecStats::AtomicPtr http3_codec_stats_;
+  // Context for upstream network filters. Always scoped to stats_scope_ ("cluster.<name>."), since
+  // network filters scope stats via context.scope() and have no stats_prefix parameter.
   UpstreamFactoryContextImpl upstream_context_;
+  // Context for upstream HTTP filters. Scoped to the server root when the correct-stats-prefix flag
+  // is enabled (the explicit "cluster.<name>." stats_prefix is then passed via FilterChainHelper),
+  // otherwise scoped to stats_scope_ to preserve legacy stat names.
+  UpstreamFactoryContextImpl http_upstream_context_;
   const std::unique_ptr<
       const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>
       happy_eyeballs_config_;

--- a/test/integration/idle_timeout_integration_test.cc
+++ b/test/integration/idle_timeout_integration_test.cc
@@ -652,20 +652,12 @@ public:
 class UpstreamIdleTimeoutVerifierFilterFactory
     : public Server::Configuration::NamedUpstreamNetworkFilterConfigFactory {
 public:
-  // The 2-arg form is pure; the production call path uses the stats_prefix overload below, so this
-  // simply delegates with an empty prefix (stats then land directly under context.scope()).
   Network::FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message& config,
+  createFilterFactoryFromProto(const Protobuf::Message&,
                                Server::Configuration::UpstreamFactoryContext& context) override {
-    return createFilterFactoryFromProto(config, EMPTY_STRING, context);
-  }
-
-  Network::FilterFactoryCb
-  createFilterFactoryFromProto(const Protobuf::Message&, const std::string& stats_prefix,
-                               Server::Configuration::UpstreamFactoryContext& context) override {
-    Stats::ScopeSharedPtr scope = context.scope().createScope(stats_prefix);
-    return [scope](Network::FilterManager& filter_manager) {
-      auto filter = std::make_shared<UpstreamIdleTimeoutVerifierFilter>(*scope);
+    Stats::Scope& scope = context.scope();
+    return [&scope](Network::FilterManager& filter_manager) {
+      auto filter = std::make_shared<UpstreamIdleTimeoutVerifierFilter>(scope);
       filter_manager.addReadFilter(filter);
       filter_manager.addAccessLogHandler(filter);
     };


### PR DESCRIPTION
## Why

Stacked on top of `fl/upstream-rbac-stats-prefix` for review before folding in.

The current base branch gives upstream HTTP filters the router pattern (server root scope + explicit `"cluster.<name>."` stats_prefix) by switching the shared `upstream_context_` to `serverScope()` and adding a **stats_prefix overload to `NamedUpstreamNetworkFilterConfigFactory`**. That overload broke CI: every subclass that overrides only the 2-arg form now hides the 3-arg one → `-Woverloaded-virtual` under `-Werror` (e.g. `test/common/filter/config_discovery_impl_test.cc`, reverse_tunnel, and several other test doubles).

## What

Use **two factory contexts** on `ClusterInfoImpl` instead of one shared context + a network-filter overload:

- `upstream_context_` — always scoped to `stats_scope_` (`"cluster.<name>."`). Used by upstream **network** filters, which scope stats via `context.scope()` and have no `stats_prefix` parameter. Unchanged from master → no behavior change, no API change.
- `http_upstream_context_` — scoped to the **server root** when `envoy.reloadable_features.upstream_http_filters_correct_stats_prefix` is on (else `stats_scope_`). Used by the upstream **HTTP** filter chain, which receives the explicit `"cluster.<name>."` prefix via `FilterChainHelper`.

Result:
- `NamedUpstreamNetworkFilterConfigFactory` is back to a **single 2-arg pure virtual** → `-Woverloaded-virtual` gone by construction.
- **reverse_tunnel** and all network-filter test doubles are untouched.
- The `idle_timeout` test filter is restored to its original form.
- Same runtime-flag gating and same emitted stats for HTTP filters (`cluster.<name>.*`).

## Testing

- `//test/common/filter:config_discovery_impl_test` (the CI-failing target), `//test/integration:idle_timeout_integration_test`, `//test/extensions/filters/http/upstream_rbac:upstream_rbac_filter_test` all pass.
- `upstream_lib` + reverse_tunnel lib build clean; format check passes.