### PR TITLE
upstream_impl: cluster-owned empty-prefix scope + sanitized HTTP stats_prefix

### DIFF
--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -1254,12 +1254,11 @@ ClusterInfoImpl::ClusterInfoImpl(
       network_filter_config_provider_manager_(
           createSingletonUpstreamNetworkFilterConfigProviderManager(server_context)),
       upstream_context_(server_context, init_manager, *stats_scope_),
-      http_upstream_context_(
-          server_context, init_manager,
-          Runtime::runtimeFeatureEnabled(
-              "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
-              ? server_context.serverScope()
-              : *stats_scope_),
+      http_filter_scope_(Runtime::runtimeFeatureEnabled(
+                             "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
+                             ? server_context.serverScope().createScope("")
+                             : stats_scope_),
+      http_upstream_context_(server_context, init_manager, *http_filter_scope_),
       happy_eyeballs_config_(
           config.upstream_connection_options().has_happy_eyeballs_config()
               ? std::make_unique<
@@ -1409,16 +1408,13 @@ ClusterInfoImpl::ClusterInfoImpl(
   // early validation of sanity of fields that we should catch at config ingestion.
   DurationUtil::durationToMilliseconds(common_lb_config_->update_merge_window());
 
-  // stats_prefix passed to the upstream HTTP filter chain. When the correct-stats-prefix flag is
-  // enabled, http_upstream_context_ is scoped to the server root, so pass an explicit
-  // "cluster.<name>." prefix (mirroring the router, which passes the HCM stat prefix). When
-  // disabled, http_upstream_context_ keeps the cluster-scoped stats_scope_, so reproduce the legacy
-  // stringified scope prefix to keep existing stat names unchanged.
+  // stats_prefix passed to the upstream HTTP filter chain. This is always the cluster's sanitized
+  // stat prefix ("cluster.<observability name>."); only the scope differs by flag (see
+  // http_filter_scope_). With the flag on, an empty-prefix scope + this prefix yields correctly
+  // namespaced stats; with it off, the cluster-scoped stats_scope_ + this prefix reproduces the
+  // legacy (repeated-prefix) stat names.
   const std::string http_stats_prefix =
-      Runtime::runtimeFeatureEnabled(
-          "envoy.reloadable_features.upstream_http_filters_correct_stats_prefix")
-          ? absl::StrCat("cluster.", name_, ".")
-          : stats_scope_->symbolTable().toString(stats_scope_->prefix());
+      stats_scope_->symbolTable().toString(stats_scope_->prefix());
 
   // Create upstream network filter factories
   const auto& filters = config.filters();

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -1150,9 +1150,12 @@ private:
   // Context for upstream network filters. Always scoped to stats_scope_ ("cluster.<name>."), since
   // network filters scope stats via context.scope() and have no stats_prefix parameter.
   UpstreamFactoryContextImpl upstream_context_;
-  // Context for upstream HTTP filters. Scoped to the server root when the correct-stats-prefix flag
-  // is enabled (the explicit "cluster.<name>." stats_prefix is then passed via FilterChainHelper),
-  // otherwise scoped to stats_scope_ to preserve legacy stat names.
+  // Scope for upstream HTTP filters, owned by the cluster so the filter stats share the cluster's
+  // lifetime. When the correct-stats-prefix flag is enabled this is a fresh empty-prefix scope (the
+  // explicit "cluster.<name>." stats_prefix is passed separately via FilterChainHelper); otherwise
+  // it is stats_scope_ so legacy stat names are unchanged.
+  Stats::ScopeSharedPtr http_filter_scope_;
+  // Context for upstream HTTP filters, backed by http_filter_scope_.
   UpstreamFactoryContextImpl http_upstream_context_;
   const std::unique_ptr<
       const envoy::config::cluster::v3::UpstreamConnectionOptions::HappyEyeballsConfig>


### PR DESCRIPTION
## Why

Stacked on `fl/upstream-rbac-stats-prefix` for review before folding in. Applies wbpcode's two refinements to the upstream HTTP filter stat scoping.

## What

Building on the two-context design (network filters keep the cluster-scoped context; HTTP filters get their own context), this addresses the two remaining review points:

1. **Stat lifetime** (review at `upstream_impl.cc:1260`/`:1465`): the HTTP context now uses a **cluster-owned empty-prefix scope** (`http_filter_scope_ = serverScope().createScope("")`) instead of the shared `server_context.serverScope()`. Upstream HTTP filter stats are released with the cluster rather than living for the server's lifetime. When the flag is off it aliases `stats_scope_`, so legacy stat names are unchanged.

2. **Sanitized prefix** (review at `upstream_impl.cc:1418`): the HTTP `stats_prefix` is now **always** `stats_scope_->symbolTable().toString(stats_scope_->prefix())` — the correct, sanitized `cluster.<observability name>.` — rather than `absl::StrCat("cluster.", name_, ".")` (raw, unsanitized name). Only the *scope* differs by flag now, not the prefix.

Net behavior (unchanged from the base branch, flag on): upstream HTTP filter stats land under `cluster.<name>.*` with a single, correctly-sanitized prefix; flag off reproduces the legacy names.

## Testing

- `//test/integration:idle_timeout_integration_test`, `//test/extensions/filters/http/upstream_rbac:upstream_rbac_filter_test`, `//test/integration:upstream_network_filter_integration_test` pass; `upstream_lib` builds clean; format check passes.